### PR TITLE
Fix error that close is not declared.

### DIFF
--- a/src/greensql.cpp
+++ b/src/greensql.cpp
@@ -19,6 +19,7 @@
 #include <string.h>
 
 #include <stdio.h>
+#include <unistd.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <fcntl.h>


### PR DESCRIPTION
My environment is debian jessie.
When I try to build this project, I got the error. (see below)
```
greensql.cpp: In static member function ‘static int GreenSQL::socket_close(int)’:
greensql.cpp:245:14: error: ‘close’ was not declared in this scope
     close(sfd);
              ^
```
This PR makes fix to this.